### PR TITLE
 Upgrade prettier to latest version (#12)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,11 @@ class PrettierChecker {
     this.fileName = fileName
   }
 
-  enterSourceUnit() {
-    this.SourceUnit()
+  async enterSourceUnit() {
+    await this.SourceUnit()
   }
 
-  SourceUnit() {
+  async SourceUnit() {
     try {
       // Check for optional dependencies with the try catch
       // Prettier is expensive to load, so only load it if needed.
@@ -42,7 +42,7 @@ class PrettierChecker {
 
       const filepath = this.fileName
 
-      const prettierRcOptions = this.prettier.resolveConfig.sync(filepath, {
+      const prettierRcOptions = await this.prettier.resolveConfig(filepath, {
         editorconfig: true
       })
 
@@ -51,8 +51,8 @@ class PrettierChecker {
         plugins: ['prettier-plugin-solidity']
       })
 
-      const formatted = this.prettier.format(this.inputSrc, prettierOptions)
-
+      const formatted = await this.prettier.format(this.inputSrc, prettierOptions)
+      
       const differences = generateDifferences(this.inputSrc, formatted)
 
       differences.forEach(difference => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,122 @@
 {
   "name": "solhint-plugin-prettier",
   "version": "0.0.5",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+  "packages": {
+    "": {
+      "name": "solhint-plugin-prettier",
+      "version": "0.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-solidity": "^1.0.0-alpha.14"
+      }
     },
-    "prettier-linter-helpers": {
+    "node_modules/@solidity-parser/parser": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.1.tgz",
+      "integrity": "sha512-PdhRFNhbTtu3x8Axm0uYpqOy/lODYQK+MlYSgqIsq2L8SFYEHJPHNUiOTAJbDGzNjjr1/n9AcIayxafR/fWmYw==",
+      "peer": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "node_modules/antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "peer": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "requires": {
+      "dependencies": {
         "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
+    },
+    "node_modules/prettier-plugin-solidity": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz",
+      "integrity": "sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==",
+      "peer": true,
+      "dependencies": {
+        "@solidity-parser/parser": "^0.16.0",
+        "semver": "^7.3.8",
+        "solidity-comments-extractor": "^0.0.7"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.3.0 || >=3.0.0-alpha.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solidity-comments-extractor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
+      "peer": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier-linter-helpers": "^1.0.0"
   },
   "peerDependencies": {
-    "prettier": "^1.15.0 || ^2.0.0",
+    "prettier": "^3.0.0",
     "prettier-plugin-solidity": "^1.0.0-alpha.14"
   }
 }


### PR DESCRIPTION
This PR is a copy of the [PR #12 to the source repository](https://github.com/fvictorio/solhint-plugin-prettier/pull/12) (from where this repo is forked from).
[PR #12](https://github.com/fvictorio/solhint-plugin-prettier/pull/12) is not yet merged, so this repository forks the source repo and merges the [PR #12](https://github.com/fvictorio/solhint-plugin-prettier/pull/12) (for use while the [PR #12](https://github.com/fvictorio/solhint-plugin-prettier/pull/12) pends to be merged).

> ## What issue this PR solves:
> 
> Current version of `solhint-plugin-prettier` with Prettier v3 throws `TypeError: this.prettier.resolveConfig.sync is not a function`. This happens because in Prettier v3 `prettier.resolveConfig.sync` [has been removed](https://prettier.io/blog/2023/07/05/3.0.0.html#change-public-apis-to-asynchronous-12574httpsgithubcomprettierprettierpull12574-12788httpsgithubcomprettierprettierpull12788-12790httpsgithubcomprettierprettierpull12790-13265httpsgithubcomprettierprettierpull13265-by-fiskerhttpsgithubcomfisker).
> ### What I did to fix it:
> 
>     * upgrade prettier to v3;
> 
>     * replace `prettier.format()` and `prettier.resolveConfig.sync()` with now asynchronous `prettier.format()` and `prettier.resolveConfig()`;
> 
>     * make `SourceUnit` method asynchronous
